### PR TITLE
8 polaris 5x localizations

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -222,9 +222,9 @@ class PolarisZoneClimate(CoordinatorEntity[PolarisCoordinator], ClimateEntity):
         | ClimateEntityFeature.TURN_ON
         | ClimateEntityFeature.TURN_OFF
     )
-    # OFF = zone off, FAN_ONLY = zone active (machine decides heat/cool/vent).
+    # OFF = zone off, AUTO = zone active (machine decides heat/cool/vent).
     # Zone entities cannot change machine mode — use PolarisMainClimate for that.
-    _attr_hvac_modes = [HVACMode.OFF, HVACMode.FAN_ONLY]
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.AUTO]
 
     def __init__(self, coordinator: PolarisCoordinator, zone_id: int) -> None:
         super().__init__(coordinator)
@@ -282,14 +282,14 @@ class PolarisZoneClimate(CoordinatorEntity[PolarisCoordinator], ClimateEntity):
 
     @property
     def hvac_mode(self) -> HVACMode:
-        """OFF if zone or machine is off. FAN_ONLY (= zone active) otherwise."""
+        """OFF if zone or machine is off. AUTO (= zone active) otherwise."""
         zone = self._zone
         if not zone or zone.is_off:
             return HVACMode.OFF
         dev = self._device
         if dev and dev.is_off:
             return HVACMode.OFF
-        return HVACMode.FAN_ONLY
+        return HVACMode.AUTO
 
     @property
     def hvac_action(self) -> HVACAction | None:
@@ -297,10 +297,10 @@ class PolarisZoneClimate(CoordinatorEntity[PolarisCoordinator], ClimateEntity):
         dev = self._device
         if not zone or zone.is_off or (dev and dev.is_off):
             return HVACAction.OFF
-        return HVACAction.FAN
+        return HVACAction.IDLE
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
-        """OFF = turn zone off (upd_zona). FAN_ONLY = turn zone on (upd_zona)."""
+        """OFF = turn zone off (upd_zona). AUTO = turn zone on (upd_zona)."""
         if hvac_mode == HVACMode.OFF:
             await self._coordinator.async_turn_zone_off(self._zone_id)
         else:

--- a/climate.py
+++ b/climate.py
@@ -108,6 +108,7 @@ class PolarisMainClimate(CoordinatorEntity[PolarisCoordinator], ClimateEntity):
     """
 
     _attr_has_entity_name = True
+    _attr_name = None
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (
         ClimateEntityFeature.TURN_ON
@@ -125,11 +126,6 @@ class PolarisMainClimate(CoordinatorEntity[PolarisCoordinator], ClimateEntity):
         super().__init__(coordinator)
         self._coordinator = coordinator
         self._attr_unique_id = f"polaris_{coordinator.serial}_main"
-
-    @property
-    def name(self) -> str:
-        dev = self._device
-        return dev.name if dev and dev.name != "Unknown" else self._coordinator.device_name
 
     @property
     def _device(self):

--- a/const.py
+++ b/const.py
@@ -34,11 +34,9 @@ TARGET_HUMIDITY_OPTIONS = {
 REVERSED_TARGET_HUMIDITY_OPTIONS = {v: k for k, v in TARGET_HUMIDITY_OPTIONS.items()}
 
 # ─── Polaris constants ───────────────────────────────────────────────
-POLARIS_SCAN_INTERVAL = 5  # seconds (local TCP port 1235)
-
 POLARIS_COOLING_MODES = {
-    0: "Riscaldamento",
-    1: "Raffrescamento",
-    2: "Deumidificazione",
-    3: "Ventilazione",
+    0: "heating",
+    1: "cooling",
+    2: "dehumidification",
+    3: "ventilation",
 }

--- a/polaris_api/models.py
+++ b/polaris_api/models.py
@@ -167,11 +167,11 @@ class PolarisDevice:
     def cooling_mode_name(self) -> str:
         """Human-readable cooling mode name."""
         return {
-            0: "Riscaldamento",
-            1: "Raffrescamento",
-            2: "Deumidificazione",
-            3: "Ventilazione",
-        }.get(self.operating_mode, "Sconosciuto")
+            0: "Heating",
+            1: "Cooling",
+            2: "Dehumidification",
+            3: "Ventilation",
+        }.get(self.operating_mode, "Unknown")
 
     @classmethod
     def from_local(cls, data: dict[str, Any]) -> PolarisDevice:

--- a/sensor.py
+++ b/sensor.py
@@ -362,6 +362,7 @@ class PolarisZoneHumiditySensor(CoordinatorEntity, SensorEntity):
 class PolarisOperatingModeSensor(CoordinatorEntity, SensorEntity):
     """Sensor showing the Polaris CU operating mode (heating/cooling type)."""
 
+    _attr_translation_key = "polaris_operating_mode"
     _attr_has_entity_name = True
     _attr_icon = "mdi:thermostat"
 
@@ -371,15 +372,11 @@ class PolarisOperatingModeSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"polaris_{coordinator.serial}_operating_mode"
 
     @property
-    def name(self) -> str:
-        return "Operating Mode"
-
-    @property
     def native_value(self) -> str | None:
         dev = self.coordinator.data.device if self.coordinator.data else None
         if not dev:
             return None
-        return POLARIS_COOLING_MODES.get(dev.operating_mode, "Sconosciuto")
+        return POLARIS_COOLING_MODES.get(dev.operating_mode, "unknown")
 
     @property
     def extra_state_attributes(self):

--- a/translations/en.json
+++ b/translations/en.json
@@ -43,6 +43,18 @@
           "natural_ventilation": "Natural Ventilation"
         }
       }
+    },
+    "sensor": {
+      "polaris_operating_mode": {
+        "name": "Operating Mode",
+        "state": {
+          "heating": "Heating",
+          "cooling": "Cooling",
+          "dehumidification": "Dehumidification",
+          "ventilation": "Ventilation",
+          "unknown": "Unknown"
+        }
+      }
     }
   }
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -43,6 +43,18 @@
           "natural_ventilation": "Ventilazione Naturale"
         }
       }
+    },
+    "sensor": {
+      "polaris_operating_mode": {
+        "name": "Modalità Operativa",
+        "state": {
+          "heating": "Riscaldamento",
+          "cooling": "Raffrescamento",
+          "dehumidification": "Deumidificazione",
+          "ventilation": "Ventilazione",
+          "unknown": "Sconosciuto"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## What changed

### Dynamic localization for Polaris entities

Polaris entities now use Home Assistant's native translation system, matching the existing behavior of Pico devices.

Previously, Polaris used hardcoded Italian/English strings directly in Python. Now:

- **Operating Mode sensor** (`PolarisOperatingModeSensor`) returns translation keys (`heating`, `cooling`, `dehumidification`, `ventilation`) instead of raw strings. HA resolves the correct label based on the user's language.
- Translation files (`en.json`, `it.json`) include full `name` and `state` entries for the operating mode sensor.
- `POLARIS_COOLING_MODES` in `const.py` now maps integers to translation keys instead of display strings.

---

## Localization limitations

Some Polaris strings cannot be localized through custom integration translation files:

| String | Reason |
|--------|--------|
| Zone entity names (e.g. `"Living Room"`) | Come from the Polaris API at runtime — cannot be put in static translation files |
| `"Temperature"` / `"Humidity"` suffix in zone sensor names | Appended dynamically to the API zone name; no static translation key possible |
| `HVACMode` labels (e.g. `"Auto"`, `"Heat"`, `"Cool"`) | Owned by HA core — custom integrations cannot override these strings |
| `cooling_mode_name` in `models.py` | Used only in debug logging, never shown in the UI — intentionally English |

---

### Zone climate mode: FAN_ONLY → AUTO

`PolarisZoneClimate` previously reported `FAN_ONLY` as the active mode, which was misleading — the zone doesn't control fan behavior, the main CU does.

Changed to `HVACMode.AUTO` to better reflect that the zone is delegating control to the machine (which may be heating, cooling, dehumidifying, or ventilating depending on `PolarisMainClimate` mode).

`hvac_action` is now `IDLE` instead of `FAN` when the zone is active, for the same reason.

### Removed dead constant

`POLARIS_SCAN_INTERVAL = 5` in `const.py` was unused — `polaris_coordinator.py` defines its own value of `30` seconds. The dead constant has been removed.
