### PR TITLE
[10]: Polaris 5x show cu and zones errors

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -35,6 +35,7 @@ PICO_PLATFORMS: list[Platform] = [
 POLARIS_PLATFORMS: list[Platform] = [
     Platform.CLIMATE,
     Platform.SENSOR,
+    Platform.BINARY_SENSOR,
 ]
 
 # Define the Pico device schema (local UDP)

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -5,7 +5,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorDeviceClass,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -106,11 +106,24 @@ class PolarisDeviceErrorBinarySensor(CoordinatorEntity, BinarySensorEntity):
             return {}
         return {"active_errors": self._coordinator.data.device.active_errors}
 
+    @property
+    def device_info(self):
+        dev = self._coordinator.data.device if self._coordinator.data else None
+        return {
+            "identifiers": {(DOMAIN, f"polaris_{self._coordinator.serial}")},
+            "name": dev.name if dev else f"Polaris {self._coordinator.serial}",
+            "manufacturer": "Tecnosystemi",
+            "model": "Polaris 5",
+        }
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self.async_write_ha_state()
+
 
 class PolarisZoneErrorBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Binary sensor: a Polaris zone has at least one active error bit."""
 
-    _attr_translation_key = "polaris_zone_error"
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
     _attr_has_entity_name = True
     _attr_icon = "mdi:alert-circle-outline"
@@ -144,3 +157,17 @@ class PolarisZoneErrorBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def extra_state_attributes(self) -> dict:
         z = self._zone
         return {"active_errors": z.active_errors} if z else {}
+
+    @property
+    def device_info(self):
+        dev = self._coordinator.data.device if self._coordinator.data else None
+        return {
+            "identifiers": {(DOMAIN, f"polaris_{self._coordinator.serial}")},
+            "name": dev.name if dev else f"Polaris {self._coordinator.serial}",
+            "manufacturer": "Tecnosystemi",
+            "model": "Polaris 5",
+        }
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self.async_write_ha_state()

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .base import BaseEntity
@@ -26,13 +27,21 @@ async def async_setup_platform(
     if discovery_info is None:
         return
 
-    # Get all coordinators from hass.data
-    coordinators = hass.data[DOMAIN]["coordinators"]
-
-    # Create binary sensor entities for each coordinator/device
     sensors = []
+
+    # ─── Pico sensors ─────────────────────────────────────────────
+    coordinators = hass.data[DOMAIN].get("coordinators", [])
     for idx, coordinator in enumerate(coordinators):
         sensors.append(PicoMaintenanceBinarySensor(coordinator, idx))
+
+    # ─── Polaris sensors (device error + per-zone error) ──────────
+    from .polaris_coordinator import PolarisCoordinator
+    polaris_coordinators = hass.data[DOMAIN].get("polaris_coordinators", [])
+    for coordinator in polaris_coordinators:
+        sensors.append(PolarisDeviceErrorBinarySensor(coordinator))
+        zones = coordinator.data.zones if coordinator.data else []
+        for zone in zones:
+            sensors.append(PolarisZoneErrorBinarySensor(coordinator, zone.zone_id))
 
     async_add_entities(sensors)
     _LOGGER.info("Added %d binary sensor(s)", len(sensors))
@@ -65,3 +74,73 @@ class PicoMaintenanceBinarySensor(BaseEntity, BinarySensorEntity):
         if self.is_on:
             return "mdi:air-filter-remove"
         return "mdi:air-filter"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Polaris binary sensors
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class PolarisDeviceErrorBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor: Polaris CU has at least one active error bit."""
+
+    _attr_translation_key = "polaris_device_error"
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:alert-circle"
+
+    def __init__(self, coordinator) -> None:
+        super().__init__(coordinator)
+        self._coordinator = coordinator
+        self._attr_unique_id = f"polaris_{coordinator.serial}_device_error"
+
+    @property
+    def is_on(self) -> bool | None:
+        if not self._coordinator.data:
+            return None
+        return self._coordinator.data.device.has_error
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        if not self._coordinator.data:
+            return {}
+        return {"active_errors": self._coordinator.data.device.active_errors}
+
+
+class PolarisZoneErrorBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor: a Polaris zone has at least one active error bit."""
+
+    _attr_translation_key = "polaris_zone_error"
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:alert-circle-outline"
+
+    def __init__(self, coordinator, zone_id: int) -> None:
+        super().__init__(coordinator)
+        self._coordinator = coordinator
+        self._zone_id = zone_id
+        self._attr_unique_id = f"polaris_{coordinator.serial}_zone_{zone_id}_error"
+
+    @property
+    def _zone(self):
+        if not self._coordinator.data:
+            return None
+        for z in self._coordinator.data.zones:
+            if z.zone_id == self._zone_id:
+                return z
+        return None
+
+    @property
+    def name(self) -> str | None:
+        z = self._zone
+        return f"{z.name.strip()} Error" if z else None
+
+    @property
+    def is_on(self) -> bool | None:
+        z = self._zone
+        return z.has_error if z is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        z = self._zone
+        return {"active_errors": z.active_errors} if z else {}

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -149,6 +149,10 @@ class PolarisZoneErrorBinarySensor(CoordinatorEntity, BinarySensorEntity):
         return f"{z.name.strip()} Error" if z else None
 
     @property
+    def available(self) -> bool:
+        return super().available and self._zone is not None
+
+    @property
     def is_on(self) -> bool | None:
         z = self._zone
         return z.has_error if z is not None else None

--- a/climate.py
+++ b/climate.py
@@ -173,7 +173,7 @@ class PolarisMainClimate(CoordinatorEntity[PolarisCoordinator], ClimateEntity):
     def current_temperature(self) -> float | None:
         """Return canal temperature if available."""
         dev = self._device
-        return float(dev.t_can) if dev and dev.t_can else None
+        return float(dev.t_can) if dev and dev.t_can is not None else None
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         if hvac_mode == HVACMode.OFF:

--- a/polaris_api/models.py
+++ b/polaris_api/models.py
@@ -7,6 +7,35 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+# Error bitmask definitions from APK R.array.cu_errors / R.array.zone_errors.
+# Index = bit position (LSB = bit 0). Empty strings = undefined/reserved bits.
+_CU_ERROR_MESSAGES: tuple[str, ...] = (
+    "E0 - No Master",
+    "",
+    "",
+    "",
+    "PIN error",
+    "E6 - Server Error",
+    "E7 - Server Error",
+    "Network error – Please check your connection",
+)
+
+_ZONE_ERROR_MESSAGES: tuple[str, ...] = (
+    "E0 - No communication",
+    "E2 - Chrono-Actuator association",
+    "E3 - Actuator failure",
+    "E4 - Actuator communication error",
+    "E5 - Low Battery",
+    "Error: status request",
+    "E7 - Server Error",
+    "Network error – Please check your connection",
+)
+
+
+def _decode_error_bitmask(mask: int, messages: tuple[str, ...]) -> list[str]:
+    """Decode LSB-first bitmask → list of active error strings (empty bits skipped)."""
+    return [msg for i, msg in enumerate(messages) if (mask >> i) & 1 and msg]
+
 
 def _parse_temp(value: Any) -> float | None:
     """Parse temperature from API/local response.
@@ -86,7 +115,12 @@ class PolarisZone:
 
     @property
     def has_error(self) -> bool:
-        return self.num_error > 0
+        return self.num_error != 0
+
+    @property
+    def active_errors(self) -> list[str]:
+        """Decode zone error bitmask → list of active error messages."""
+        return _decode_error_bitmask(self.num_error, _ZONE_ERROR_MESSAGES)
 
     @classmethod
     def from_local(cls, data: dict[str, Any]) -> PolarisZone:
@@ -162,6 +196,15 @@ class PolarisDevice:
     @property
     def is_on(self) -> bool:
         return not self.is_off
+
+    @property
+    def has_error(self) -> bool:
+        return self.num_errors != 0
+
+    @property
+    def active_errors(self) -> list[str]:
+        """Decode CU error bitmask → list of active error messages."""
+        return _decode_error_bitmask(self.num_errors, _CU_ERROR_MESSAGES)
 
     @property
     def cooling_mode_name(self) -> str:

--- a/polaris_api/polaris_client.py
+++ b/polaris_api/polaris_client.py
@@ -180,7 +180,15 @@ class PolarisLocalClient:
          "fan_set":...,"shu_set":...,"is_crono":...,"pin":...}
         """
         effective_is_off = is_off if is_off is not None else zone.is_off
-        effective_temp = set_temp if set_temp is not None else (zone.set_temp or 20.0)
+        if set_temp is not None:
+            effective_temp = set_temp
+        elif zone.set_temp is not None:
+            effective_temp = zone.set_temp
+        else:
+            raise ValueError(
+                f"Cannot update zone {zone.zone_id}: no target temperature known. "
+                "Set a temperature explicitly."
+            )
         effective_crono = is_crono if is_crono is not None else zone.is_crono_mode
         set_temp_int = round(effective_temp * 10)
 

--- a/sensor.py
+++ b/sensor.py
@@ -101,7 +101,7 @@ class PicoTemperatureSensor(BaseEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
-        if not self.coordinator.data or not self.coordinator.data.sensors or not self.coordinator.data.sensors.temperature:
+        if not self.coordinator.data or not self.coordinator.data.sensors or self.coordinator.data.sensors.temperature is None:
             return None
         return self.coordinator.data.sensors.temperature_celsius
 
@@ -125,7 +125,7 @@ class PicoHumiditySensor(BaseEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
-        if not self.coordinator.data or not self.coordinator.data.sensors or not self.coordinator.data.sensors.humidity:
+        if not self.coordinator.data or not self.coordinator.data.sensors or self.coordinator.data.sensors.humidity is None:
             return None
         return self.coordinator.data.sensors.humidity_percent
 
@@ -149,7 +149,7 @@ class PicoAirQualitySensor(BaseEntity, SensorEntity):
     @property
     def native_value(self) -> int | None:
         """Return the state of the sensor."""
-        if not self.coordinator.data or not self.coordinator.data.sensors or not self.coordinator.data.sensors.air_quality:
+        if not self.coordinator.data or not self.coordinator.data.sensors or self.coordinator.data.sensors.air_quality is None:
             return None
         return self.coordinator.data.sensors.air_quality
 
@@ -173,14 +173,14 @@ class PicoTVOCSensor(BaseEntity, SensorEntity):
     @property
     def native_value(self) -> int | None:
         """Return the state of the sensor."""
-        if not self.coordinator.data or not self.coordinator.data.sensors or not self.coordinator.data.sensors.tvoc:
+        if not self.coordinator.data or not self.coordinator.data.sensors or self.coordinator.data.sensors.tvoc is None:
             return None
         return self.coordinator.data.sensors.tvoc
 
     @property
     def icon(self) -> str:
         """Return the icon based on TVOC level."""
-        if not self.coordinator.data or not self.coordinator.data.sensors or not self.coordinator.data.sensors.tvoc:
+        if not self.coordinator.data or not self.coordinator.data.sensors or self.coordinator.data.sensors.tvoc is None:
             return "mdi:chemical-weapon"
 
         tvoc = self.coordinator.data.sensors.tvoc
@@ -223,14 +223,14 @@ class PicoECO2Sensor(BaseEntity, SensorEntity):
     @property
     def native_value(self) -> int | None:
         """Return the state of the sensor."""
-        if not self.coordinator.data or not self.coordinator.data.sensors or not self.coordinator.data.sensors.eco2:
+        if not self.coordinator.data or not self.coordinator.data.sensors or self.coordinator.data.sensors.eco2 is None:
             return None
         return self.coordinator.data.sensors.eco2
 
     @property
     def icon(self) -> str:
         """Return the icon based on eCO2 level."""
-        if not self.coordinator.data or not self.coordinator.data.sensors or not self.coordinator.data.sensors.eco2:
+        if not self.coordinator.data or not self.coordinator.data.sensors or self.coordinator.data.sensors.eco2 is None:
             return "mdi:molecule-co2"
 
         eco2 = self.coordinator.data.sensors.eco2
@@ -284,6 +284,10 @@ class PolarisZoneTemperatureSensor(CoordinatorEntity, SensorEntity):
         return None
 
     @property
+    def available(self) -> bool:
+        return super().available and self._zone is not None
+
+    @property
     def name(self) -> str:
         zone = self._zone
         zone_name = zone.name.strip() if zone else f"Zone {self._zone_id}"
@@ -332,6 +336,10 @@ class PolarisZoneHumiditySensor(CoordinatorEntity, SensorEntity):
             if z.zone_id == self._zone_id:
                 return z
         return None
+
+    @property
+    def available(self) -> bool:
+        return super().available and self._zone is not None
 
     @property
     def name(self) -> str:

--- a/translations/en.json
+++ b/translations/en.json
@@ -59,9 +59,6 @@
     "binary_sensor": {
       "polaris_device_error": {
         "name": "Device Error"
-      },
-      "polaris_zone_error": {
-        "name": "Zone Error"
       }
     }
   }

--- a/translations/en.json
+++ b/translations/en.json
@@ -55,6 +55,14 @@
           "unknown": "Unknown"
         }
       }
+    },
+    "binary_sensor": {
+      "polaris_device_error": {
+        "name": "Device Error"
+      },
+      "polaris_zone_error": {
+        "name": "Zone Error"
+      }
     }
   }
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -59,9 +59,6 @@
     "binary_sensor": {
       "polaris_device_error": {
         "name": "Errore Dispositivo"
-      },
-      "polaris_zone_error": {
-        "name": "Errore Zona"
       }
     }
   }

--- a/translations/it.json
+++ b/translations/it.json
@@ -55,6 +55,14 @@
           "unknown": "Sconosciuto"
         }
       }
+    },
+    "binary_sensor": {
+      "polaris_device_error": {
+        "name": "Errore Dispositivo"
+      },
+      "polaris_zone_error": {
+        "name": "Errore Zona"
+      }
     }
   }
 }


### PR DESCRIPTION
# Polaris – CU and Zone Error Binary Sensors

## Summary

Adds two new binary sensor types to the Polaris integration that expose the error bitmask reported by the Control Unit over local TCP.

Error bit definitions are sourced directly from the official Tecnosystemi app (`R.array.cu_errors` / `R.array.zone_errors`).

---

## New Entities

### `PolarisDeviceErrorBinarySensor` (one per CU)

- **Device class**: `PROBLEM` — state shows as `Problem` / `OK` (localized by HA core)
- **Name**: localized — `Device Error` (EN) / `Errore Dispositivo` (IT)
- **Attribute** `active_errors`: list of active error strings decoded from the 8-bit CU bitmask

Example when bit 0 and bit 4 are set:
```
active_errors: ["E0 - No Master", "PIN error"]
```

### `PolarisZoneErrorBinarySensor` (one per zone)

- **Device class**: `PROBLEM`
- **Name**: `{Zone Name} Error` — zone name is dynamic from the device API
- **Attribute** `active_errors`: list of active error strings decoded from the 8-bit zone bitmask

Example:
```
active_errors: ["E3 - Actuator failure", "E5 - Low Battery"]
```

Both sensors are registered under the Polaris device in the HA device registry.

---

## Implementation Details

- `polaris_api/models.py`: added `_CU_ERROR_MESSAGES` and `_ZONE_ERROR_MESSAGES` tuples (8 entries each, LSB = bit 0), `_decode_error_bitmask()` helper, and `has_error` / `active_errors` properties on `PolarisDevice` and `PolarisZone`
- `binary_sensor.py`: added `PolarisDeviceErrorBinarySensor` and `PolarisZoneErrorBinarySensor`; setup now iterates `polaris_coordinators` from `hass.data`
- `translations/en.json` + `translations/it.json`: added `binary_sensor.polaris_device_error` translation key

---

## Limitations

- `active_errors` attribute values are English strings from the app's string resources — they are not localized
- Zone entity name suffix `" Error"` is hardcoded English (same pattern as existing `" Temperature"` / `" Humidity"` sensors) because the zone name is dynamic from the API
